### PR TITLE
Updates the version of `typer`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ profyle = "profyle.main:app"
 python = ">=3.9,<4.0"
 jinja2 = "^3.1.2"
 uvicorn = ">=0.20.0"
-typer = {extras = ["all"], version = "^0.7.0"}
+typer = {extras = ["all"], version = "^0.15.0"}
 viztracer = "^0.16.0"
 fastapi = ">=0.70.0"
 pydantic-settings = "^2.0.3"


### PR DESCRIPTION
Updates the version of `typer`, to ensure the underlying version of `rich` is the latest, fixing issues with previous versions of `rich`.

See: https://github.com/hynek/structlog/issues/576